### PR TITLE
21202 Flask Session Timeouts

### DIFF
--- a/bfapi/config.py
+++ b/bfapi/config.py
@@ -100,7 +100,7 @@ GEOAXIS_SECRET    = os.getenv('GEOAXIS_SECRET')
 JOB_WORKER_INTERVAL = timedelta(seconds=60)
 JOB_WORKER_MAX_RETRIES = 3
 JOB_TTL = timedelta(hours=2)
-SESSION_TTL = timedelta(minutes=30)
+SESSION_TTL = timedelta(minutes=15)
 
 _services = _getservices()
 

--- a/bfapi/middleware.py
+++ b/bfapi/middleware.py
@@ -32,6 +32,8 @@ PATTERNS_PUBLIC_ENDPOINTS = (
     re.compile(r'^/v0/scene/[^/]+.TIF$'),
 )
 
+ENDPOINTS_DO_NOT_EXTEND_SESSION = ['/v0/job', '/v0/productline']
+
 
 def apply_default_response_headers(response: flask.Response) -> flask.Response:
     response.headers.setdefault('X-Frame-Options', 'DENY')
@@ -43,8 +45,7 @@ def apply_default_response_headers(response: flask.Response) -> flask.Response:
 
 def strip_cookie_headers(response: flask.Response) -> flask.Response:
     # do not extend life of Flask session on automated status checks
-    statusRequestPaths = ['/v0/job', '/v0/productline']
-    if flask.request.method == 'GET' and flask.request.script_root in statusRequestPaths:
+    if flask.request.method == 'GET' and flask.request.script_root in ENDPOINTS_DO_NOT_EXTEND_SESSION:
         response.headers.remove('Set-Cookie')
     return response
 

--- a/bfapi/middleware.py
+++ b/bfapi/middleware.py
@@ -43,7 +43,7 @@ def apply_default_response_headers(response: flask.Response) -> flask.Response:
 
 def strip_cookie_headers(response: flask.Response) -> flask.Response:
     # do not extend life of Flask session on automated status checks
-    statusRequestPaths = ['v0/job', 'v0/productline']
+    statusRequestPaths = ['/v0/job', '/v0/productline']
     if flask.request.method == 'GET' and flask.request.script_root in statusRequestPaths:
         response.headers.remove('Set-Cookie')
     return response

--- a/bfapi/middleware.py
+++ b/bfapi/middleware.py
@@ -41,6 +41,14 @@ def apply_default_response_headers(response: flask.Response) -> flask.Response:
     return response
 
 
+def strip_cookie_headers(response: flask.Response) -> flask.Response:
+    # do not extend life of Flask session on automated status checks
+    statusRequestPaths = ['v0/job', 'v0/productline']
+    if flask.request.method == 'GET' and flask.request.script_root in statusRequestPaths:
+        response.headers.remove('Set-Cookie')
+    return response
+
+
 def auth_filter():
     log = logging.getLogger(__name__)
     request = flask.request

--- a/bfapi/routes/__init__.py
+++ b/bfapi/routes/__init__.py
@@ -73,3 +73,9 @@ def logout():
     flask.session.clear()
     log.info('Logged out', actor=flask.request.user.user_id, action='log out')
     return 'You have been logged out'
+
+
+def keepalive():
+    return flask.jsonify({
+        'keepalive': 'true'
+    })

--- a/bfapi/server.py
+++ b/bfapi/server.py
@@ -25,6 +25,7 @@ def apply_middlewares(app: flask.Flask):
     app.before_request(middleware.csrf_filter)
     app.before_request(middleware.auth_filter)
     app.after_request(middleware.apply_default_response_headers)
+    app.after_request(middleware.check_if_session_extends)
 
     CORS(app,
          origins=middleware.PATTERNS_AUTHORIZED_ORIGINS,

--- a/bfapi/server.py
+++ b/bfapi/server.py
@@ -25,7 +25,7 @@ def apply_middlewares(app: flask.Flask):
     app.before_request(middleware.csrf_filter)
     app.before_request(middleware.auth_filter)
     app.after_request(middleware.apply_default_response_headers)
-    app.after_request(middleware.check_if_session_extends)
+    app.after_request(middleware.strip_cookie_headers)
 
     CORS(app,
          origins=middleware.PATTERNS_AUTHORIZED_ORIGINS,
@@ -42,6 +42,7 @@ def attach_routes(app: flask.Flask):
 
     # Protected endpoints
     app.add_url_rule(methods=['GET'], rule='/logout', view_func=routes.logout)
+    app.add_url_rule(methods=['GET'], rule='/keepalive', view_func=routes.keepalive)
     app.add_url_rule(methods=['GET'], rule='/v0/user', view_func=routes.v0.get_user_data)
     app.add_url_rule(methods=['GET'], rule='/v0/algorithm', view_func=routes.v0.list_algorithms)
     app.add_url_rule(methods=['GET'], rule='/v0/algorithm/<service_id>', view_func=routes.v0.get_algorithm)


### PR DESCRIPTION
Removing the session extension on API calls that are status checks, such that AFK users can still be appropriately logged out even as the client continously pings the API for Status. 