### PR TITLE
Add BF key to credentials

### DIFF
--- a/JenkinsFile
+++ b/JenkinsFile
@@ -278,8 +278,8 @@ node {
                 sh "mkdir -p integration-tests"
             }
             withCredentials([
-              file(credentialsId: "${POSTMAN_SECRET_FILE}", variable: "POSTMAN_FILE")
-	      [$class: 'StringBinding', credentialsId: "bf_test_key", variable: "BF_GPKG_KEY"]
+		    	file(credentialsId: "${POSTMAN_SECRET_FILE}", variable: "POSTMAN_FILE"),
+		    	[$class: 'StringBinding', credentialsId: "${env.BF_GPKG_KEY}", variable: "BF_GPKG_KEY"]
             ]) {
                 withEnv([
                   "PATH+=${root}/integration-tests/node_modules/newman/bin:${nodejs}/bin",
@@ -386,7 +386,8 @@ node {
     if(!params.SKIP_INTEGRATION_TESTS) {
         stage("Phase Two Integration Tests") {
             withCredentials([
-              file(credentialsId: "${POSTMAN_SECRET_FILE}", variable: "POSTMAN_FILE")
+		    	file(credentialsId: "${POSTMAN_SECRET_FILE}", variable: "POSTMAN_FILE"),
+		    	[$class: 'StringBinding', credentialsId: "${env.BF_GPKG_KEY}", variable: "BF_GPKG_KEY"]
             ]) {
                 withEnv([
                   "PATH+=${root}/integration-tests/node_modules/newman/bin:${nodejs}/bin",

--- a/JenkinsFile
+++ b/JenkinsFile
@@ -279,6 +279,7 @@ node {
             }
             withCredentials([
               file(credentialsId: "${POSTMAN_SECRET_FILE}", variable: "POSTMAN_FILE")
+	      [$class: 'StringBinding', credentialsId: "bf_test_key", variable: "BF_GPKG_KEY"]
             ]) {
                 withEnv([
                   "PATH+=${root}/integration-tests/node_modules/newman/bin:${nodejs}/bin",


### PR DESCRIPTION
This change will enable the geopackage test to run during the integration tests.  The tests require a BF API key to run.

28389