### PR TITLE
Scene Fixes

### DIFF
--- a/src/main/java/org/venice/beachfront/bfapi/model/Scene.java
+++ b/src/main/java/org/venice/beachfront/bfapi/model/Scene.java
@@ -217,4 +217,13 @@ public class Scene {
 	public String getImageBand(String bandName) {
 		return this.rawJson.get("properties").get("bands").get(bandName).asText();
 	}
+	
+	public String getLocationProperty() {
+		JsonNode locationNode = this.rawJson.get("properties").get("location");
+		if (locationNode != null) {
+			return locationNode.asText();
+		} else {
+			return null;
+		}
+	}
 }

--- a/src/main/java/org/venice/beachfront/bfapi/services/SceneService.java
+++ b/src/main/java/org/venice/beachfront/bfapi/services/SceneService.java
@@ -149,7 +149,7 @@ public class SceneService {
 
 		Scene scene = new Scene();
 		try {
-			piazzaLogger.log(String.format("Beginnining parsing of successful response of Scene %s data.", sceneId),
+			piazzaLogger.log(String.format("Beginning parsing of successful response of Scene %s data.", sceneId),
 					Severity.INFORMATIONAL);
 			scene.setRawJson(responseJson);
 			scene.setSceneId(platform + ":" + responseJson.get("id").asText());
@@ -157,12 +157,11 @@ public class SceneService {
 			scene.setResolution(responseJson.get("properties").get("resolution").asInt());
 			scene.setCaptureTime(DateTime.parse(responseJson.get("properties").get("acquiredDate").asText()));
 			scene.setSensorName(responseJson.get("properties").get("sensorName").asText());
-			if (responseJson.get("properties").has("location")) {
-				scene.setUri(responseJson.get("properties").get("location").asText());
-			}
+			scene.setUri(UriComponentsBuilder.newInstance().scheme(this.iaBrokerProtocol).host(this.iaBrokerServer).port(this.iaBrokerPort)
+							.path(scenePath).toUriString());
 
 			try {
-				// The response from ia-broker is a GeoJSON feature. Convert to Geometry.
+				// The response from IA-Broker is a GeoJSON feature. Convert to Geometry.
 				FeatureJSON featureReader = new FeatureJSON();
 				String geoJsonString = new ObjectMapper().writeValueAsString(responseJson);
 				SimpleFeature feature = featureReader.readFeature(geoJsonString);
@@ -259,7 +258,7 @@ public class SceneService {
 		switch (Scene.parsePlatform(scene.getSceneId())) {
 		case Scene.PLATFORM_RAPIDEYE:
 		case Scene.PLATFORM_PLANETSCOPE:
-			return Arrays.asList(scene.getUri().toString());
+			return Arrays.asList(scene.getLocationProperty());
 		case Scene.PLATFORM_LANDSAT:
 			return Arrays.asList(scene.getImageBand("coastal"), scene.getImageBand("swir1"));
 		case Scene.PLATFORM_SENTINEL:

--- a/src/test/java/org/venice/beachfront/bfapi/services/SceneServiceTests.java
+++ b/src/test/java/org/venice/beachfront/bfapi/services/SceneServiceTests.java
@@ -75,11 +75,11 @@ public class SceneServiceTests {
 
 		scene.setSceneId("landsat:abcd");
 		inputFileNames = this.sceneService.getSceneInputFileNames(scene);
-		assertEquals(Arrays.asList("coastal.TIF", "multispectral.TIF"), inputFileNames);
+		assertEquals(Arrays.asList("coastal.TIF", "swir1.TIF"), inputFileNames);
 
 		scene.setSceneId("sentinel:abcd");
 		inputFileNames = this.sceneService.getSceneInputFileNames(scene);
-		assertEquals(Arrays.asList("B02.JP2", "B08.JP2"), inputFileNames);
+		assertEquals(Arrays.asList("coastal.JP2", "swir1.JP2"), inputFileNames);
 
 		scene.setSceneId("bogus:abcd");
 		inputFileNames = this.sceneService.getSceneInputFileNames(scene);
@@ -96,6 +96,7 @@ public class SceneServiceTests {
 		bands.set("coastal", JsonNodeFactory.instance.textNode("COASTAL_URL"));
 		bands.set("blue", JsonNodeFactory.instance.textNode("BLUE_URL"));
 		bands.set("nir", JsonNodeFactory.instance.textNode("NIR_URL"));
+		bands.set("swir1", JsonNodeFactory.instance.textNode("SWIR1_URL"));
 		JsonNode properties = JsonNodeFactory.instance.objectNode().set("bands", bands);
 		JsonNode rawJson = JsonNodeFactory.instance.objectNode().set("properties", properties);
 
@@ -114,7 +115,7 @@ public class SceneServiceTests {
 
 		scene.setSceneId("landsat:abcd");
 		inputURLs = this.sceneService.getSceneInputURLs(scene);
-		assertEquals(Arrays.asList("COASTAL_URL", "SCENE_URL"), inputURLs);
+		assertEquals(Arrays.asList("COASTAL_URL", "SWIR1_URL"), inputURLs);
 
 		scene.setSceneId("sentinel:abcd");
 		inputURLs = this.sceneService.getSceneInputURLs(scene);

--- a/src/test/java/org/venice/beachfront/bfapi/services/SceneServiceTests.java
+++ b/src/test/java/org/venice/beachfront/bfapi/services/SceneServiceTests.java
@@ -98,6 +98,7 @@ public class SceneServiceTests {
 		bands.set("nir", JsonNodeFactory.instance.textNode("NIR_URL"));
 		bands.set("swir1", JsonNodeFactory.instance.textNode("SWIR1_URL"));
 		JsonNode properties = JsonNodeFactory.instance.objectNode().set("bands", bands);
+		((ObjectNode) properties).put("location", "LOCATION_URL");
 		JsonNode rawJson = JsonNodeFactory.instance.objectNode().set("properties", properties);
 
 		Scene scene = new Scene();
@@ -107,11 +108,11 @@ public class SceneServiceTests {
 
 		scene.setSceneId("rapideye:abcd");
 		inputURLs = this.sceneService.getSceneInputURLs(scene);
-		assertEquals(Arrays.asList("SCENE_URL"), inputURLs);
+		assertEquals(Arrays.asList("LOCATION_URL"), inputURLs);
 
 		scene.setSceneId("planetscope:abcd");
 		inputURLs = this.sceneService.getSceneInputURLs(scene);
-		assertEquals(Arrays.asList("SCENE_URL"), inputURLs);
+		assertEquals(Arrays.asList("LOCATION_URL"), inputURLs);
 
 		scene.setSceneId("landsat:abcd");
 		inputURLs = this.sceneService.getSceneInputURLs(scene);
@@ -278,7 +279,7 @@ public class SceneServiceTests {
 		assertEquals(3, scene.getResolution());
 		assertEquals(DateTime.parse("2018-02-26T07:28:08Z"), scene.getCaptureTime());
 		assertEquals("mockSensorName", scene.getSensorName());
-		assertEquals("https://mock-uri.localdomain/foo/tile.avi", scene.getUri());
+		assertEquals("https://bf-ia-broker-test.localdomain:443/planet/rapideye/EXTERNAL_ID", scene.getUri());
 		assertEquals(Scene.STATUS_INACTIVE, scene.getStatus());
 		assertEquals(0.5, scene.getTide(), 0.0001);
 		assertEquals(0.1, scene.getTideMin24H(), 0.0001);
@@ -309,7 +310,7 @@ public class SceneServiceTests {
 		assertEquals(3, scene.getResolution());
 		assertEquals(DateTime.parse("2018-02-26T07:28:08Z"), scene.getCaptureTime());
 		assertEquals("mockSensorName", scene.getSensorName());
-		assertEquals("https://mock-uri.localdomain/foo/tile.avi", scene.getUri());
+		assertEquals("https://bf-ia-broker-test.localdomain:443/planet/landsat/EXTERNAL_ID", scene.getUri());
 		assertEquals(Scene.STATUS_ACTIVE, scene.getStatus()); // This is the big difference from rapideye; landsat
 																// should always be active
 		assertNull(scene.getTide());
@@ -323,16 +324,16 @@ public class SceneServiceTests {
 		JsonNode responseJson = new ObjectMapper().readTree(
 				getClass().getClassLoader().getResourceAsStream(String.format("%s%s%s", "scene", File.separator, "getLandsatScene.json")));
 		Mockito.when(this.restTemplate.getForEntity(Mockito.any(), Mockito.eq(JsonNode.class)))
-		.then(new Answer<ResponseEntity<JsonNode>>() {
-			public ResponseEntity<JsonNode> answer(InvocationOnMock invocation) {
-				Object[] args = invocation.getArguments();
-				assertEquals(URI.class, args[0].getClass());
-				assertEquals(
-						"https://bf-ia-broker-test.localdomain:443/planet/landsat/EXTERNAL_ID?PL_API_KEY=api-abc-123&tides=false",
-						((URI) args[0]).toString());
-				return new ResponseEntity<JsonNode>(responseJson, HttpStatus.OK);
-			}
-		});
+				.then(new Answer<ResponseEntity<JsonNode>>() {
+					public ResponseEntity<JsonNode> answer(InvocationOnMock invocation) {
+						Object[] args = invocation.getArguments();
+						assertEquals(URI.class, args[0].getClass());
+						assertEquals(
+								"https://bf-ia-broker-test.localdomain:443/planet/landsat/EXTERNAL_ID?PL_API_KEY=api-abc-123&tides=false",
+								((URI) args[0]).toString());
+						return new ResponseEntity<JsonNode>(responseJson, HttpStatus.OK);
+					}
+				});
 		// Test
 		Scene scene = this.sceneService.getScene("landsat:EXTERNAL_ID", "api-abc-123", false);
 		// Verify

--- a/src/test/java/org/venice/beachfront/bfapi/services/SceneServiceTests.java
+++ b/src/test/java/org/venice/beachfront/bfapi/services/SceneServiceTests.java
@@ -318,6 +318,34 @@ public class SceneServiceTests {
 	}
 
 	@Test
+	public void testGetLandsatScene() throws UserException, IOException {
+		// Mock
+		JsonNode responseJson = new ObjectMapper().readTree(
+				getClass().getClassLoader().getResourceAsStream(String.format("%s%s%s", "scene", File.separator, "getLandsatScene.json")));
+		Mockito.when(this.restTemplate.getForEntity(Mockito.any(), Mockito.eq(JsonNode.class)))
+		.then(new Answer<ResponseEntity<JsonNode>>() {
+			public ResponseEntity<JsonNode> answer(InvocationOnMock invocation) {
+				Object[] args = invocation.getArguments();
+				assertEquals(URI.class, args[0].getClass());
+				assertEquals(
+						"https://bf-ia-broker-test.localdomain:443/planet/landsat/EXTERNAL_ID?PL_API_KEY=api-abc-123&tides=false",
+						((URI) args[0]).toString());
+				return new ResponseEntity<JsonNode>(responseJson, HttpStatus.OK);
+			}
+		});
+		// Test
+		Scene scene = this.sceneService.getScene("landsat:EXTERNAL_ID", "api-abc-123", false);
+		// Verify
+		assertEquals("EXTERNAL_ID", scene.getExternalId());
+		assertEquals(50, scene.getCloudCover(), 0.0001);
+		assertEquals(30, scene.getResolution());
+		assertEquals(DateTime.parse("2016-09-30T09:45:02.625661Z"), scene.getCaptureTime());
+		assertEquals("Landsat8", scene.getSensorName());
+		assertEquals(Scene.STATUS_ACTIVE, scene.getStatus()); // This is the big difference from rapideye; landsat
+																// should always be active
+	}
+
+	@Test
 	public void testGetScene401() {
 		Mockito.when(this.restTemplate.getForEntity(Mockito.any(), Mockito.eq(JsonNode.class))).then(new Answer<ResponseEntity<?>>() {
 			public ResponseEntity<?> answer(InvocationOnMock invocation) {

--- a/src/test/java/org/venice/beachfront/bfapi/services/SceneServiceTests.java
+++ b/src/test/java/org/venice/beachfront/bfapi/services/SceneServiceTests.java
@@ -336,7 +336,7 @@ public class SceneServiceTests {
 		// Test
 		Scene scene = this.sceneService.getScene("landsat:EXTERNAL_ID", "api-abc-123", false);
 		// Verify
-		assertEquals("EXTERNAL_ID", scene.getExternalId());
+		assertEquals("test", scene.getExternalId());
 		assertEquals(50, scene.getCloudCover(), 0.0001);
 		assertEquals(30, scene.getResolution());
 		assertEquals(DateTime.parse("2016-09-30T09:45:02.625661Z"), scene.getCaptureTime());

--- a/src/test/resources/scene/getLandsatScene.json
+++ b/src/test/resources/scene/getLandsatScene.json
@@ -1,0 +1,57 @@
+{
+    "type": "Feature",
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    15.924750537604071,
+                    51.34596904618805
+                ],
+                [
+                    18.50200153028106,
+                    50.89916674100784
+                ],
+                [
+                    17.730005198796224,
+                    49.20070207975821
+                ],
+                [
+                    15.243013317912679,
+                    49.64207902545733
+                ],
+                [
+                    15.924750537604071,
+                    51.34596904618805
+                ]
+            ]
+        ]
+    },
+    "properties": {
+        "acquiredDate": "2016-09-30T09:45:02.625661Z",
+        "bands": {
+            "blue": "https://mocktest.s3.amazonaws.com/L8/190/025/test/test_B2.TIF",
+            "cirrus": "https://mocktest.s3.amazonaws.com/L8/190/025/test/test_B9.TIF",
+            "coastal": "https://mocktest.s3.amazonaws.com/L8/190/025/test/test_B1.TIF",
+            "green": "https://mocktest.s3.amazonaws.com/L8/190/025/test/test_B3.TIF",
+            "nir": "https://mocktest.s3.amazonaws.com/L8/190/025/test/test_B5.TIF",
+            "panchromatic": "https://mocktest.s3.amazonaws.com/L8/190/025/test/test_B8.TIF",
+            "red": "https://mocktest.s3.amazonaws.com/L8/190/025/test/test_B4.TIF",
+            "swir1": "https://mocktest.s3.amazonaws.com/L8/190/025/test/test_B6.TIF",
+            "swir2": "https://mocktest.s3.amazonaws.com/L8/190/025/test/test_B7.TIF",
+            "tirs1": "https://mocktest.s3.amazonaws.com/L8/190/025/test/test_B10.TIF",
+            "tirs2": "https://mocktest.s3.amazonaws.com/L8/190/025/test/test_B11.TIF"
+        },
+        "cloudCover": 50,
+        "fileFormat": "geotiff",
+        "resolution": 30,
+        "sensorName": "Landsat8"
+    },
+    "id": "test",
+    "bbox": [
+        15.243013317912679,
+        49.20070207975821,
+        18.50200153028106,
+        51.34596904618805
+    ]
+}


### PR DESCRIPTION
There were a variety of problems with the Scene Service that required fixing:

1) Landsat Scene parsing crashing due to no location property provided
2) URI Property was incorrect for all scenes. This should represent the Broker URI used to query/activate the Scene - nothing with file names.
3) Updating the retrieval point for PS/RE imagery file names.
4) Incorrect file names being used to populate LS URLs
5) Adding tests which contain raw inputs from IA Broker. Also updating tests to reflect all of the above changed logic. 

For confirming logic in the PR, please refer to https://github.com/venicegeo/bf-api/blob/1.0-Sentinel/bfapi/service/scenes.py directly for existing functionality with 1.0. 