### PR TITLE
Oauth multi-CN response support

### DIFF
--- a/src/main/java/org/venice/beachfront/bfapi/model/oauth/AbstractCommonName.java
+++ b/src/main/java/org/venice/beachfront/bfapi/model/oauth/AbstractCommonName.java
@@ -13,12 +13,12 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 
-public interface GeoAxisCommonName {
+public interface AbstractCommonName {
 	public String toString();
 	
-	public static class Deserializer extends JsonDeserializer<GeoAxisCommonName> {
+	public static class Deserializer extends JsonDeserializer<AbstractCommonName> {
 		@Override
-		public GeoAxisCommonName deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+		public AbstractCommonName deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
 			TreeNode node = p.getCodec().readTree(p);
 			if (node.isValueNode() && ((JsonNode)node).isTextual()) {
 				return new SingleString(((JsonNode)node).asText());
@@ -40,7 +40,7 @@ public interface GeoAxisCommonName {
 		}
 	}
 	
-	public static class SingleString implements GeoAxisCommonName {
+	public static class SingleString implements AbstractCommonName {
 		private String commonName;
 		public SingleString(String commonName) {
 			this.commonName = commonName;
@@ -52,7 +52,7 @@ public interface GeoAxisCommonName {
 		}
 	}
 	
-	public static class StringList implements GeoAxisCommonName {
+	public static class StringList implements AbstractCommonName {
 		private List<String> commonName;
 		public StringList(List<String> commonName) {
 			this.commonName = Collections.unmodifiableList(commonName);

--- a/src/main/java/org/venice/beachfront/bfapi/model/oauth/AbstractCommonName.java
+++ b/src/main/java/org/venice/beachfront/bfapi/model/oauth/AbstractCommonName.java
@@ -13,6 +13,13 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 
+/**
+ * AbstractCommonName is a polymorphic interface intended to enable parsing
+ * of OAuth profile responses that can have their CN listed either as a
+ * single string or a list of strings. For supporting this use case, Jackson
+ * requires a custom deserializer, which is implemented here, along with 
+ * some container classes for the different forms of CN data.
+ */
 public interface AbstractCommonName {
 	public String toString();
 	

--- a/src/main/java/org/venice/beachfront/bfapi/model/oauth/GeoAxisCommonName.java
+++ b/src/main/java/org/venice/beachfront/bfapi/model/oauth/GeoAxisCommonName.java
@@ -1,0 +1,67 @@
+package org.venice.beachfront.bfapi.model.oauth;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public interface GeoAxisCommonName {
+	public String toString();
+	
+	public static class Deserializer extends JsonDeserializer<GeoAxisCommonName> {
+		@Override
+		public GeoAxisCommonName deserialize(JsonParser p, DeserializationContext ctxt) throws IOException, JsonProcessingException {
+			TreeNode node = p.getCodec().readTree(p);
+			if (node.isValueNode() && ((JsonNode)node).isTextual()) {
+				return new SingleString(((JsonNode)node).asText());
+			}
+			if (node.isArray()) {
+				LinkedList<String> cns = new LinkedList<>();
+				for (int i=0; i < node.size(); i++) {
+					if (!node.get(i).isValueNode()) {
+						throw new JsonParseException(p, "Non-string element found in commonname array: " + node.toString());						
+					}
+					cns.add(((JsonNode)node.get(i)).asText());
+				}
+				if (cns.size() < 1) {
+					throw new JsonParseException(p, "Empty commonname array");
+				}
+				return new StringList(cns);
+			}
+			throw new JsonParseException(p, "Could not parse commonname");						
+		}
+	}
+	
+	public static class SingleString implements GeoAxisCommonName {
+		private String commonName;
+		public SingleString(String commonName) {
+			this.commonName = commonName;
+		}
+		
+		@Override
+		public String toString() {
+			return this.commonName;
+		}
+	}
+	
+	public static class StringList implements GeoAxisCommonName {
+		private List<String> commonName;
+		public StringList(List<String> commonName) {
+			this.commonName = Collections.unmodifiableList(commonName);
+		}
+
+		@Override
+		public String toString() {
+			// Only return the first common name in the list
+			return this.commonName.get(0);
+		}
+	}
+}

--- a/src/main/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBody.java
+++ b/src/main/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBody.java
@@ -27,7 +27,7 @@ public class ProfileResponseBody {
 	private String dn;
 
 	@JsonProperty(value = "commonname", required = false)
-	private GeoAxisCommonName commonName;
+	private AbstractCommonName commonName;
 
 	@JsonProperty(value = "memberof", required = false)
 	private String memberOf;
@@ -45,7 +45,7 @@ public class ProfileResponseBody {
 		super();
 	}
 
-	public ProfileResponseBody(String dn, GeoAxisCommonName commonName, String memberOf, String firstname, String lastname, String id) {
+	public ProfileResponseBody(String dn, AbstractCommonName commonName, String memberOf, String firstname, String lastname, String id) {
 		this.dn = dn;
 		this.commonName = commonName;
 		this.memberOf = memberOf;
@@ -58,7 +58,7 @@ public class ProfileResponseBody {
 		return dn;
 	}
 
-	public GeoAxisCommonName getCommonName() {
+	public AbstractCommonName getCommonName() {
 		return commonName;
 	}
 

--- a/src/main/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBody.java
+++ b/src/main/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBody.java
@@ -15,24 +15,11 @@
  **/
 package org.venice.beachfront.bfapi.model.oauth;
 
-import java.io.IOException;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-
 import org.springframework.http.HttpStatus;
 import org.venice.beachfront.bfapi.model.exception.UserException;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.core.JsonParseException;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonDeserializer;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ProfileResponseBody {

--- a/src/main/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBody.java
+++ b/src/main/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBody.java
@@ -109,7 +109,7 @@ public class ProfileResponseBody {
 		if (this.id != null && this.id.length() > 0) {
 			return this.id;
 		}
-		throw new UserException("Could not obtain a user name from OAuth profile response", this.commonName.toString(),
+		throw new UserException("Could not obtain a user name from OAuth profile response", this.toString(),
 				HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 

--- a/src/main/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBody.java
+++ b/src/main/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBody.java
@@ -15,11 +15,24 @@
  **/
 package org.venice.beachfront.bfapi.model.oauth;
 
+import java.io.IOException;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.venice.beachfront.bfapi.model.exception.UserException;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.TreeNode;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ProfileResponseBody {
@@ -27,7 +40,7 @@ public class ProfileResponseBody {
 	private String dn;
 
 	@JsonProperty(value = "commonname", required = false)
-	private String commonName;
+	private GeoAxisCommonName commonName;
 
 	@JsonProperty(value = "memberof", required = false)
 	private String memberOf;
@@ -45,7 +58,7 @@ public class ProfileResponseBody {
 		super();
 	}
 
-	public ProfileResponseBody(String dn, String commonName, String memberOf, String firstname, String lastname, String id) {
+	public ProfileResponseBody(String dn, GeoAxisCommonName commonName, String memberOf, String firstname, String lastname, String id) {
 		this.dn = dn;
 		this.commonName = commonName;
 		this.memberOf = memberOf;
@@ -58,7 +71,7 @@ public class ProfileResponseBody {
 		return dn;
 	}
 
-	public String getCommonName() {
+	public GeoAxisCommonName getCommonName() {
 		return commonName;
 	}
 
@@ -76,8 +89,8 @@ public class ProfileResponseBody {
 		if (this.dn != null && this.dn.length() > 0) {
 			return this.dn;
 		}
-		if (this.commonName != null && this.commonName.length() > 0 && this.memberOf != null && this.memberOf.length() > 0) {
-			return String.format("%s@%s", this.commonName, this.memberOf);
+		if (this.commonName != null && this.commonName.toString().length() > 0 && this.memberOf != null && this.memberOf.length() > 0) {
+			return String.format("%s@%s", this.commonName.toString(), this.memberOf);
 		}
 		if (this.firstname != null && this.firstname.length() > 0 &&
 				this.lastname != null && this.lastname.length() > 0 &&
@@ -90,13 +103,13 @@ public class ProfileResponseBody {
 	}
 
 	public String getComputedUserName() throws UserException {
-		if (this.commonName != null && this.commonName.length() > 0) {
-			return this.commonName;
+		if (this.commonName != null && this.commonName.toString().length() > 0) {
+			return this.commonName.toString();
 		}
 		if (this.id != null && this.id.length() > 0) {
 			return this.id;
 		}
-		throw new UserException("Could not obtain a user name from OAuth profile response", this.commonName,
+		throw new UserException("Could not obtain a user name from OAuth profile response", this.commonName.toString(),
 				HttpStatus.INTERNAL_SERVER_ERROR);
 	}
 
@@ -104,5 +117,4 @@ public class ProfileResponseBody {
 		getComputedUserId();
 		getComputedUserName();
 	}
-
 }

--- a/src/main/java/org/venice/beachfront/bfapi/services/OAuthService.java
+++ b/src/main/java/org/venice/beachfront/bfapi/services/OAuthService.java
@@ -29,8 +29,6 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.FormHttpMessageConverter;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;

--- a/src/main/java/org/venice/beachfront/bfapi/services/PiazzaService.java
+++ b/src/main/java/org/venice/beachfront/bfapi/services/PiazzaService.java
@@ -37,7 +37,6 @@ import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.HttpServerErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.venice.beachfront.bfapi.model.Algorithm;
-import org.venice.beachfront.bfapi.model.Job;
 import org.venice.beachfront.bfapi.model.exception.UserException;
 import org.venice.beachfront.bfapi.model.piazza.StatusMetadata;
 import org.venice.beachfront.bfapi.services.converter.GeoPackageConverter;

--- a/src/test/java/org/venice/beachfront/bfapi/controllers/OAuthControllerTests.java
+++ b/src/test/java/org/venice/beachfront/bfapi/controllers/OAuthControllerTests.java
@@ -32,6 +32,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.venice.beachfront.bfapi.model.UserProfile;
 import org.venice.beachfront.bfapi.model.exception.UserException;
+import org.venice.beachfront.bfapi.model.oauth.GeoAxisCommonName;
 import org.venice.beachfront.bfapi.model.oauth.ProfileResponseBody;
 import org.venice.beachfront.bfapi.services.OAuthService;
 import org.venice.beachfront.bfapi.services.UserProfileService;
@@ -80,7 +81,7 @@ public class OAuthControllerTests {
 		String mockAuthCode = "mockAuthCode";
 		String mockToken = "mockToken";
 		Mockito.doReturn(mockToken).when(oauthService).requestAccessToken(Mockito.eq(mockAuthCode));
-		ProfileResponseBody mockProfileResponse = new ProfileResponseBody("dn", "common", "member", null, null, null);
+		ProfileResponseBody mockProfileResponse = new ProfileResponseBody("dn", new GeoAxisCommonName.SingleString("common"), "member", null, null, null);
 		Mockito.doReturn(mockProfileResponse).when(oauthService).requestOAuthProfile(Mockito.eq(mockToken));
 		UserProfile mockUserProfile = new UserProfile("userId", "userName", "apiKey", new DateTime());
 		Mockito.doReturn(mockUserProfile).when(oauthService).getOrCreateUser(Mockito.eq(mockProfileResponse.getComputedUserId()),

--- a/src/test/java/org/venice/beachfront/bfapi/controllers/OAuthControllerTests.java
+++ b/src/test/java/org/venice/beachfront/bfapi/controllers/OAuthControllerTests.java
@@ -32,7 +32,7 @@ import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.venice.beachfront.bfapi.model.UserProfile;
 import org.venice.beachfront.bfapi.model.exception.UserException;
-import org.venice.beachfront.bfapi.model.oauth.GeoAxisCommonName;
+import org.venice.beachfront.bfapi.model.oauth.AbstractCommonName;
 import org.venice.beachfront.bfapi.model.oauth.ProfileResponseBody;
 import org.venice.beachfront.bfapi.services.OAuthService;
 import org.venice.beachfront.bfapi.services.UserProfileService;
@@ -81,7 +81,7 @@ public class OAuthControllerTests {
 		String mockAuthCode = "mockAuthCode";
 		String mockToken = "mockToken";
 		Mockito.doReturn(mockToken).when(oauthService).requestAccessToken(Mockito.eq(mockAuthCode));
-		ProfileResponseBody mockProfileResponse = new ProfileResponseBody("dn", new GeoAxisCommonName.SingleString("common"), "member", null, null, null);
+		ProfileResponseBody mockProfileResponse = new ProfileResponseBody("dn", new AbstractCommonName.SingleString("common"), "member", null, null, null);
 		Mockito.doReturn(mockProfileResponse).when(oauthService).requestOAuthProfile(Mockito.eq(mockToken));
 		UserProfile mockUserProfile = new UserProfile("userId", "userName", "apiKey", new DateTime());
 		Mockito.doReturn(mockUserProfile).when(oauthService).getOrCreateUser(Mockito.eq(mockProfileResponse.getComputedUserId()),

--- a/src/test/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBodyTests.java
+++ b/src/test/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBodyTests.java
@@ -24,7 +24,7 @@ public class ProfileResponseBodyTests {
 		MockitoAnnotations.initMocks(this);
 
 		SimpleModule module = new SimpleModule();
-		module.addDeserializer(GeoAxisCommonName.class, new GeoAxisCommonName.Deserializer());
+		module.addDeserializer(AbstractCommonName.class, new AbstractCommonName.Deserializer());
 		this.objectMapper.registerModule(module);
 	}
 	
@@ -70,10 +70,10 @@ public class ProfileResponseBodyTests {
 	@Test
 	public void testComputedUserIdPriorities() throws UserException {
 		// Mock
-		ProfileResponseBody fullBody = new ProfileResponseBody("distinguished-name", new GeoAxisCommonName.SingleString("common-name"), "member-of", "first-name", "last-name", "id");
-		ProfileResponseBody dnBody = new ProfileResponseBody("distinguished-name", new GeoAxisCommonName.SingleString("common-name"), "member-of", null, null, null);
-		ProfileResponseBody singleCNBody = new ProfileResponseBody(null, new GeoAxisCommonName.SingleString("common-name"), "member-of", null, null, null);
-		ProfileResponseBody multiCNBody = new ProfileResponseBody(null, new GeoAxisCommonName.StringList(Arrays.asList("common-name-1", "common-name-2")) , "member-of", null, null, null);
+		ProfileResponseBody fullBody = new ProfileResponseBody("distinguished-name", new AbstractCommonName.SingleString("common-name"), "member-of", "first-name", "last-name", "id");
+		ProfileResponseBody dnBody = new ProfileResponseBody("distinguished-name", new AbstractCommonName.SingleString("common-name"), "member-of", null, null, null);
+		ProfileResponseBody singleCNBody = new ProfileResponseBody(null, new AbstractCommonName.SingleString("common-name"), "member-of", null, null, null);
+		ProfileResponseBody multiCNBody = new ProfileResponseBody(null, new AbstractCommonName.StringList(Arrays.asList("common-name-1", "common-name-2")) , "member-of", null, null, null);
 		ProfileResponseBody nameIdBody = new ProfileResponseBody(null, null, null, "firstname", "lastname", "id");
 		ProfileResponseBody invalidBody = new ProfileResponseBody(null, null, null, null, null, null);
 
@@ -95,10 +95,10 @@ public class ProfileResponseBodyTests {
 	@Test
 	public void testComputedUserNamePriorities() throws UserException {
 		// Mock
-		ProfileResponseBody fullBody = new ProfileResponseBody("distinguished-name", new GeoAxisCommonName.SingleString("common-name"), "member-of", "first-name", "last-name", "id");
-		ProfileResponseBody dnBody = new ProfileResponseBody("distinguished-name", new GeoAxisCommonName.SingleString("common-name"), "member-of", null, null, null);
-		ProfileResponseBody singleCNBody = new ProfileResponseBody(null, new GeoAxisCommonName.SingleString("common-name"), "member-of", null, null, null);
-		ProfileResponseBody multiCNBody = new ProfileResponseBody(null, new GeoAxisCommonName.StringList(Arrays.asList("common-name-1", "common-name-2")) , "member-of", null, null, null);
+		ProfileResponseBody fullBody = new ProfileResponseBody("distinguished-name", new AbstractCommonName.SingleString("common-name"), "member-of", "first-name", "last-name", "id");
+		ProfileResponseBody dnBody = new ProfileResponseBody("distinguished-name", new AbstractCommonName.SingleString("common-name"), "member-of", null, null, null);
+		ProfileResponseBody singleCNBody = new ProfileResponseBody(null, new AbstractCommonName.SingleString("common-name"), "member-of", null, null, null);
+		ProfileResponseBody multiCNBody = new ProfileResponseBody(null, new AbstractCommonName.StringList(Arrays.asList("common-name-1", "common-name-2")) , "member-of", null, null, null);
 		ProfileResponseBody nameIdBody = new ProfileResponseBody(null, null, null, "firstname", "lastname", "id");
 		ProfileResponseBody invalidBody = new ProfileResponseBody(null, null, null, null, null, null);
 

--- a/src/test/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBodyTests.java
+++ b/src/test/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBodyTests.java
@@ -1,0 +1,58 @@
+package org.venice.beachfront.bfapi.model.oauth;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.commons.io.IOUtils;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ProfileResponseBodyTests {
+	private ObjectMapper objectMapper;
+	
+	@Before
+	public void setup() {
+		this.objectMapper= new ObjectMapper();
+	}
+	
+	@Test
+	public void testParseSingleCNGeoAxisBody() throws IOException {
+		// Mock
+		String responseJson = IOUtils.toString(
+				this.getClass().getClassLoader().getResourceAsStream(String.format("%s%s%s", "model", File.separator, "geoaxis-single-cn.json")),
+				"UTF-8");
+		
+		// Test
+		ProfileResponseBody body = this.objectMapper.readerFor(ProfileResponseBody.class).readValue(responseJson);
+		
+		// Asserts
+		Assert.assertEquals("distinguished-name.test.localdomain", body.getDn());
+		Assert.assertEquals("testuser.localdomain", body.getCommonName());
+		Assert.assertEquals("testorg.localdomain", body.getMemberOf());
+		Assert.assertEquals("FirstName", body.getFirstname());
+		Assert.assertEquals("LastName", body.getLastname());
+		Assert.assertEquals("test-id-123", body.getId());
+	}
+
+	@Test
+	public void testParseMultiCNGeoAxisBody() throws IOException {
+		// Mock
+		String responseJson = IOUtils.toString(
+				this.getClass().getClassLoader().getResourceAsStream(String.format("%s%s%s", "model", File.separator, "geoaxis-multi-cn.json")),
+				"UTF-8");
+		
+		// Test
+		ProfileResponseBody body = this.objectMapper.readerFor(ProfileResponseBody.class).readValue(responseJson);
+		
+		// Asserts
+		Assert.assertEquals("distinguished-name.test.localdomain", body.getDn());
+		Assert.assertEquals("testuser.localdomain", body.getCommonName());
+		Assert.assertEquals("testorg.localdomain", body.getMemberOf());
+		Assert.assertEquals("FirstName", body.getFirstname());
+		Assert.assertEquals("LastName", body.getLastname());
+		Assert.assertEquals("test-id-123", body.getId());
+	}
+}

--- a/src/test/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBodyTests.java
+++ b/src/test/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBodyTests.java
@@ -2,11 +2,7 @@ package org.venice.beachfront.bfapi.model.oauth;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBodyTests.java
+++ b/src/test/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBodyTests.java
@@ -7,20 +7,23 @@ import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 
 public class ProfileResponseBodyTests {
+	@Spy
 	private ObjectMapper objectMapper;
 	
 	@Before
 	public void setup() {
-		ObjectMapper mapper = new ObjectMapper();
+		MockitoAnnotations.initMocks(this);
+
 		SimpleModule module = new SimpleModule();
 		module.addDeserializer(GeoAxisCommonName.class, new GeoAxisCommonName.Deserializer());
-		mapper.registerModule(module);
-		this.objectMapper = mapper;
+		this.objectMapper.registerModule(module);
 	}
 	
 	

--- a/src/test/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBodyTests.java
+++ b/src/test/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBodyTests.java
@@ -9,14 +9,20 @@ import org.junit.Before;
 import org.junit.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 
 public class ProfileResponseBodyTests {
 	private ObjectMapper objectMapper;
 	
 	@Before
 	public void setup() {
-		this.objectMapper= new ObjectMapper();
+		ObjectMapper mapper = new ObjectMapper();
+		SimpleModule module = new SimpleModule();
+		module.addDeserializer(GeoAxisCommonName.class, new GeoAxisCommonName.Deserializer());
+		mapper.registerModule(module);
+		this.objectMapper = mapper;
 	}
+	
 	
 	@Test
 	public void testParseSingleCNGeoAxisBody() throws IOException {
@@ -26,11 +32,11 @@ public class ProfileResponseBodyTests {
 				"UTF-8");
 		
 		// Test
-		ProfileResponseBody body = this.objectMapper.readerFor(ProfileResponseBody.class).readValue(responseJson);
+		ProfileResponseBody body = objectMapper.readValue(responseJson, ProfileResponseBody.class);
 		
 		// Asserts
 		Assert.assertEquals("distinguished-name.test.localdomain", body.getDn());
-		Assert.assertEquals("testuser.localdomain", body.getCommonName());
+		Assert.assertEquals("testuser.localdomain", body.getCommonName().toString());
 		Assert.assertEquals("testorg.localdomain", body.getMemberOf());
 		Assert.assertEquals("FirstName", body.getFirstname());
 		Assert.assertEquals("LastName", body.getLastname());
@@ -45,11 +51,11 @@ public class ProfileResponseBodyTests {
 				"UTF-8");
 		
 		// Test
-		ProfileResponseBody body = this.objectMapper.readerFor(ProfileResponseBody.class).readValue(responseJson);
+		ProfileResponseBody body = objectMapper.readValue(responseJson, ProfileResponseBody.class);
 		
 		// Asserts
 		Assert.assertEquals("distinguished-name.test.localdomain", body.getDn());
-		Assert.assertEquals("testuser.localdomain", body.getCommonName());
+		Assert.assertEquals("testuser1.localdomain", body.getCommonName().toString());
 		Assert.assertEquals("testorg.localdomain", body.getMemberOf());
 		Assert.assertEquals("FirstName", body.getFirstname());
 		Assert.assertEquals("LastName", body.getLastname());

--- a/src/test/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBodyTests.java
+++ b/src/test/java/org/venice/beachfront/bfapi/model/oauth/ProfileResponseBodyTests.java
@@ -2,6 +2,10 @@ package org.venice.beachfront.bfapi.model.oauth;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.junit.Assert;
@@ -9,6 +13,8 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
+import org.springframework.http.HttpStatus;
+import org.venice.beachfront.bfapi.model.exception.UserException;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -63,5 +69,55 @@ public class ProfileResponseBodyTests {
 		Assert.assertEquals("FirstName", body.getFirstname());
 		Assert.assertEquals("LastName", body.getLastname());
 		Assert.assertEquals("test-id-123", body.getId());
+	}
+	
+	@Test
+	public void testComputedUserIdPriorities() throws UserException {
+		// Mock
+		ProfileResponseBody fullBody = new ProfileResponseBody("distinguished-name", new GeoAxisCommonName.SingleString("common-name"), "member-of", "first-name", "last-name", "id");
+		ProfileResponseBody dnBody = new ProfileResponseBody("distinguished-name", new GeoAxisCommonName.SingleString("common-name"), "member-of", null, null, null);
+		ProfileResponseBody singleCNBody = new ProfileResponseBody(null, new GeoAxisCommonName.SingleString("common-name"), "member-of", null, null, null);
+		ProfileResponseBody multiCNBody = new ProfileResponseBody(null, new GeoAxisCommonName.StringList(Arrays.asList("common-name-1", "common-name-2")) , "member-of", null, null, null);
+		ProfileResponseBody nameIdBody = new ProfileResponseBody(null, null, null, "firstname", "lastname", "id");
+		ProfileResponseBody invalidBody = new ProfileResponseBody(null, null, null, null, null, null);
+
+		// Asserts
+		Assert.assertEquals("distinguished-name", fullBody.getComputedUserId());
+		Assert.assertEquals("distinguished-name", dnBody.getComputedUserId());
+		Assert.assertEquals("common-name@member-of", singleCNBody.getComputedUserId());
+		Assert.assertEquals("common-name-1@member-of", multiCNBody.getComputedUserId());
+		Assert.assertEquals("id@lastname-firstname", nameIdBody.getComputedUserId());
+		try {
+			String id = invalidBody.getComputedUserId();
+			Assert.fail("expected exception getting invalid user id, instead got: " + id);
+		} catch (UserException e) {
+			Assert.assertTrue(e.getMessage().contains("Could not obtain a user ID from OAuth profile response"));
+			Assert.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, e.getRecommendedStatusCode());
+		}
+	}
+	
+	@Test
+	public void testComputedUserNamePriorities() throws UserException {
+		// Mock
+		ProfileResponseBody fullBody = new ProfileResponseBody("distinguished-name", new GeoAxisCommonName.SingleString("common-name"), "member-of", "first-name", "last-name", "id");
+		ProfileResponseBody dnBody = new ProfileResponseBody("distinguished-name", new GeoAxisCommonName.SingleString("common-name"), "member-of", null, null, null);
+		ProfileResponseBody singleCNBody = new ProfileResponseBody(null, new GeoAxisCommonName.SingleString("common-name"), "member-of", null, null, null);
+		ProfileResponseBody multiCNBody = new ProfileResponseBody(null, new GeoAxisCommonName.StringList(Arrays.asList("common-name-1", "common-name-2")) , "member-of", null, null, null);
+		ProfileResponseBody nameIdBody = new ProfileResponseBody(null, null, null, "firstname", "lastname", "id");
+		ProfileResponseBody invalidBody = new ProfileResponseBody(null, null, null, null, null, null);
+
+		// Asserts
+		Assert.assertEquals("common-name", fullBody.getComputedUserName());
+		Assert.assertEquals("common-name", dnBody.getComputedUserName());
+		Assert.assertEquals("common-name", singleCNBody.getComputedUserName());
+		Assert.assertEquals("common-name-1", multiCNBody.getComputedUserName());
+		Assert.assertEquals("id", nameIdBody.getComputedUserName());
+		try {
+			String username = invalidBody.getComputedUserName();
+			Assert.fail("expected exception getting invalid user name, instead got: " + username);
+		} catch (UserException e) {
+			Assert.assertTrue(e.getMessage().contains("Could not obtain a user name from OAuth profile response"));
+			Assert.assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, e.getRecommendedStatusCode());
+		}
 	}
 }

--- a/src/test/java/org/venice/beachfront/bfapi/services/OAuthServiceTests.java
+++ b/src/test/java/org/venice/beachfront/bfapi/services/OAuthServiceTests.java
@@ -49,7 +49,7 @@ import org.springframework.web.client.RestTemplate;
 import org.venice.beachfront.bfapi.model.UserProfile;
 import org.venice.beachfront.bfapi.model.exception.UserException;
 import org.venice.beachfront.bfapi.model.oauth.AccessTokenResponseBody;
-import org.venice.beachfront.bfapi.model.oauth.GeoAxisCommonName;
+import org.venice.beachfront.bfapi.model.oauth.AbstractCommonName;
 import org.venice.beachfront.bfapi.model.oauth.ProfileResponseBody;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -80,7 +80,7 @@ public class OAuthServiceTests {
 	public void setup() {
 		MockitoAnnotations.initMocks(this);
 		SimpleModule module = new SimpleModule();
-		module.addDeserializer(GeoAxisCommonName.class, new GeoAxisCommonName.Deserializer());
+		module.addDeserializer(AbstractCommonName.class, new AbstractCommonName.Deserializer());
 		this.objectMapper.registerModule(module);
 
 		ReflectionTestUtils.setField(this.oauthService, "domain", "test.localdomain");

--- a/src/test/java/org/venice/beachfront/bfapi/services/OAuthServiceTests.java
+++ b/src/test/java/org/venice/beachfront/bfapi/services/OAuthServiceTests.java
@@ -46,6 +46,7 @@ import org.springframework.web.client.RestTemplate;
 import org.venice.beachfront.bfapi.model.UserProfile;
 import org.venice.beachfront.bfapi.model.exception.UserException;
 import org.venice.beachfront.bfapi.model.oauth.AccessTokenResponseBody;
+import org.venice.beachfront.bfapi.model.oauth.GeoAxisCommonName;
 import org.venice.beachfront.bfapi.model.oauth.ProfileResponseBody;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -159,7 +160,7 @@ public class OAuthServiceTests {
 	@Test
 	public void testRequestOAuthProfileSuccess() throws UserException {
 		String mockAccessToken = "mock-access-token-321";
-		ProfileResponseBody mockResponseBody = new ProfileResponseBody("test-dn", mockAccessToken, "test-member-of", null, null, null);
+		ProfileResponseBody mockResponseBody = new ProfileResponseBody("test-dn", new GeoAxisCommonName.SingleString(mockAccessToken), "test-member-of", null, null, null);
 
 		Mockito.when(this.restTemplate.exchange(Mockito.eq(this.oauthProfileUrl), Mockito.eq(HttpMethod.GET), Mockito.any(),
 				Mockito.eq(String.class))).then(new Answer<ResponseEntity<String>>() {

--- a/src/test/java/org/venice/beachfront/bfapi/services/PiazzaServiceTests.java
+++ b/src/test/java/org/venice/beachfront/bfapi/services/PiazzaServiceTests.java
@@ -27,9 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
-import org.hamcrest.BaseMatcher;
 import org.hamcrest.CustomMatcher;
-import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.junit.Assert;
 import org.junit.Before;

--- a/src/test/resources/model/geoaxis-multi-cn.json
+++ b/src/test/resources/model/geoaxis-multi-cn.json
@@ -1,0 +1,8 @@
+{
+	"DN": "distinguished-name.test.localdomain",
+	"commonname": ["testuser1.localdomain", "testuser2.localdomain"],
+	"memberof": "testorg.localdomain",
+	"firstname": "FirstName",
+	"lastname": "LastName",
+	"ID": "test-id-123"
+}

--- a/src/test/resources/model/geoaxis-single-cn.json
+++ b/src/test/resources/model/geoaxis-single-cn.json
@@ -1,0 +1,8 @@
+{
+	"DN": "distinguished-name.test.localdomain",
+	"commonname": "testuser.localdomain",
+	"memberof": "testorg.localdomain",
+	"firstname": "FirstName",
+	"lastname": "LastName",
+	"ID": "test-id-123"
+}


### PR DESCRIPTION
Includes tests for supporting multi-CN oauth responses, along with a custom Jackson deserializer for handling this.

Also includes tests for prioritizing the use of DN/CN/ID for finding user ID/name.