### PR TITLE
Activation time & logging updates

### DIFF
--- a/src/main/java/org/venice/beachfront/bfapi/services/PiazzaService.java
+++ b/src/main/java/org/venice/beachfront/bfapi/services/PiazzaService.java
@@ -86,19 +86,16 @@ public class PiazzaService {
 		try {
 			piazzaLogger.log(String.format("Waiting for Activation for Job %s", jobId), Severity.INFORMATIONAL);
 			scene = sceneFuture.get();
-			piazzaLogger.log(String.format("Job %s Scene has been activated for Scene ID %s", jobId, scene.getSceneId()),
-					Severity.INFORMATIONAL);
 			
 			// calculate diff between now and when job started activation
 			piazzaLogger.log(
 				String.format(
-						"Job %s completed activation in %d seconds for Scene ID %s. Scene platorm: %s.", 
+						"Job %s Scene has been activated for Scene ID %s, Scene platorm: %s, completed activation in %d seconds", 
 						jobId, 
-						new Duration(activationStart, new DateTime()).getStandardSeconds(),
 						Scene.parseExternalId(scene.getSceneId()),
-						Scene.parsePlatform(scene.getSceneId())),
+						Scene.parsePlatform(scene.getSceneId()),
+						new Duration(activationStart, new DateTime()).getStandardSeconds()),
 				Severity.INFORMATIONAL);
-
 		} catch (InterruptedException | ExecutionException e) {
 			piazzaLogger.log(String.format("Getting Active Scene failed for Job %s", jobId), Severity.ERROR);
 			callback.updateStatus(jobId, Job.STATUS_ERROR);

--- a/src/main/java/org/venice/beachfront/bfapi/services/PiazzaService.java
+++ b/src/main/java/org/venice/beachfront/bfapi/services/PiazzaService.java
@@ -89,19 +89,41 @@ public class PiazzaService {
 			piazzaLogger.log(String.format("Job %s Scene has been activated for Scene ID %s", jobId, scene.getSceneId()),
 					Severity.INFORMATIONAL);
 			
-			// calculate diff between now and when job started activation
-			String.format("Job %s completed activation in %d seconds.", 
-					jobId, new Duration(activationStart, new DateTime()).getStandardSeconds(),
-			Severity.INFORMATIONAL);
+			// using scene ID, get the scene type from format 'type:scene'
+			String sceneType = null;
+			if (scene!=null && scene.getSceneId()!=null) {
+				int separatorIndex = scene.getSceneId().indexOf(":");
+				if (separatorIndex!=-1) {
+					sceneType = scene.getSceneId().substring(0, separatorIndex);
+				}
+			}
+
+			// only log activation for those NOT sentinel, landsat, and landsat_pds. These do not have activation
+			if (sceneType!=null && 
+					!sceneType.equalsIgnoreCase(Scene.PLATFORM_PLANET_SENTINEL) && 
+					!sceneType.equalsIgnoreCase(Scene.PLATFORM_PLANET_LANDSAT) && 
+					!sceneType.equalsIgnoreCase(Scene.PLATFORM_LOCALINDEX_LANDSAT)) {
+
+				// calculate diff between now and when job started activation
+				piazzaLogger.log(
+					String.format(
+							"Job %s completed activation in %d seconds for Scene ID %s.", 
+							jobId, 
+							new Duration(activationStart, new DateTime()).getStandardSeconds(),
+							scene.getSceneId()), 
+					Severity.INFORMATIONAL);
+			}
 		} catch (InterruptedException | ExecutionException e) {
 			piazzaLogger.log(String.format("Getting Active Scene failed for Job %s", jobId), Severity.ERROR);
 			callback.updateStatus(jobId, Job.STATUS_ERROR);
 			
 			// calculate diff between now and when job started activation
-			String.format("Job %s failed activation in %d seconds.", 
-					jobId, new Duration(activationStart, new DateTime()).getStandardSeconds(),
-			Severity.INFORMATIONAL);
-						
+			piazzaLogger.log(
+					String.format("Job %s failed activation in %d seconds.", 
+							jobId, 
+							new Duration(activationStart, new DateTime()).getStandardSeconds()),
+					Severity.INFORMATIONAL);
+
 			return;
 		}
 

--- a/src/main/java/org/venice/beachfront/bfapi/services/PiazzaService.java
+++ b/src/main/java/org/venice/beachfront/bfapi/services/PiazzaService.java
@@ -89,30 +89,16 @@ public class PiazzaService {
 			piazzaLogger.log(String.format("Job %s Scene has been activated for Scene ID %s", jobId, scene.getSceneId()),
 					Severity.INFORMATIONAL);
 			
-			// using scene ID, get the scene type from format 'type:scene'
-			String sceneType = null;
-			if (scene!=null && scene.getSceneId()!=null) {
-				int separatorIndex = scene.getSceneId().indexOf(":");
-				if (separatorIndex!=-1) {
-					sceneType = scene.getSceneId().substring(0, separatorIndex);
-				}
-			}
+			// calculate diff between now and when job started activation
+			piazzaLogger.log(
+				String.format(
+						"Job %s completed activation in %d seconds for Scene ID %s. Scene platorm: %s.", 
+						jobId, 
+						new Duration(activationStart, new DateTime()).getStandardSeconds(),
+						Scene.parseExternalId(scene.getSceneId()),
+						Scene.parsePlatform(scene.getSceneId())),
+				Severity.INFORMATIONAL);
 
-			// only log activation for those NOT sentinel, landsat, and landsat_pds. These do not have activation
-			if (sceneType!=null && 
-					!sceneType.equalsIgnoreCase(Scene.PLATFORM_PLANET_SENTINEL) && 
-					!sceneType.equalsIgnoreCase(Scene.PLATFORM_PLANET_LANDSAT) && 
-					!sceneType.equalsIgnoreCase(Scene.PLATFORM_LOCALINDEX_LANDSAT)) {
-
-				// calculate diff between now and when job started activation
-				piazzaLogger.log(
-					String.format(
-							"Job %s completed activation in %d seconds for Scene ID %s.", 
-							jobId, 
-							new Duration(activationStart, new DateTime()).getStandardSeconds(),
-							scene.getSceneId()), 
-					Severity.INFORMATIONAL);
-			}
 		} catch (InterruptedException | ExecutionException e) {
 			piazzaLogger.log(String.format("Getting Active Scene failed for Job %s", jobId), Severity.ERROR);
 			callback.updateStatus(jobId, Job.STATUS_ERROR);


### PR DESCRIPTION
Updating PiazzaService to only log activation times if the scene type is from one that includes an activation process. This avoids throwing off the metrics averages on calculation.